### PR TITLE
Only attempt to deserialize if value is not None

### DIFF
--- a/python/sedona/sql/types.py
+++ b/python/sedona/sql/types.py
@@ -43,6 +43,10 @@ class GeometryType(UserDefinedType):
         return dumps(obj)
 
     def deserialize(self, datum):
+        # Do not try and process null geometry
+        if datum is None:
+            return None
+        
         bytes_data = b''.join([struct.pack('b', el) for el in datum])
         geom = loads(bytes_data)
         return geom


### PR DESCRIPTION

## Did you read the Contributor Guide?

- Yes, I have read [Contributor Rules](https://sedona.apache.org/community/rule/) and [Contributor Development Guide](https://sedona.apache.org/community/develop/)


## Is this PR related to a JIRA ticket?

- No, this is a bugfix.


## What changes were proposed in this PR?

Only try to deserialize WKB if it is not null. Prevents an issue calling `.toPandas()` if there are null geometries.


## How was this patch tested?

Locally


## Did this PR include necessary documentation updates?

- No, this PR does not affect any public API so no need to change the docs.
